### PR TITLE
Feature/hsls q adjustment

### DIFF
--- a/DSPProfiles/STEG.json
+++ b/DSPProfiles/STEG.json
@@ -1,0 +1,55 @@
+﻿{
+    "version":  "1.0",
+    "Description":  "STEG (MDSP6 / MDSP10 / MDSP12 / MDSP6II / MDSP8 /  DSP-S6 / MDSP10D / DSP-S12 / SS-DSP12 / SS-DSP12II / MDSP12D / MDSP16 / MDSP16D / SS-DSP16 II / MDSP24D)",
+    "processName":  "STEG*",
+    "QDivider":  1,
+    "QDecimals":  2,
+    "GainDecimals":  1,
+    "FreqDecimals":  0,
+    "DecimalSeparator":  ".",
+    "StartingPositionHint":  "Please hover F/Hz edit box and hit hotkey",
+    "AdminRightsRequired":  "false",
+    "HotkeyOrDelayPreference":  "Hotkey",
+    "KeystrokeSequence":  [
+                              {
+                                  "MouseClick":  "left",
+                                  "Delay_ms":  50
+                              },
+                              {
+                                  "Keys":  "FREQ",
+                                  "Delay_ms":  200
+                              },
+                              {
+                                  "MouseChangePositionY":  "+18",
+                                  "Delay_ms":  10
+                              },
+                              {
+                                  "MouseClick":  "left",
+                                  "Delay_ms":  50
+                              },
+                              {
+                                  "Keys":  "GAIN",
+                                  "Delay_ms":  200
+                              },
+                              {
+                                  "MouseChangePositionY":  "+117",
+                                  "Delay_ms":  10
+                              },
+                              {
+                                  "MouseClick":  "left",
+                                  "Delay_ms":  50
+                              },
+                              {
+                                  "Keys":  "QVALUE",
+                                  "Delay_ms":  200
+                              },
+                              {
+                                  "MouseChangePositionY":  "-135",
+                                  "Delay_ms":  10
+                              },
+                              {
+                                  "MouseChangePositionX":  "+37",
+                                  "Delay_ms":  10
+                              }
+                          ]
+}

--- a/Modules/Assistant-Functions.psm1
+++ b/Modules/Assistant-Functions.psm1
@@ -5,12 +5,12 @@
 # Date: 2025-11-25
 # ============================================
 
-# Parse copied EQ text data from clipboard and return an array of objects with Freq, Q, and Gain properties.
+# Parse copied EQ text data from clipboard and return an array of objects with Freq, Q, Gain, Type and bandNumber properties.
 <#
 .SYNOPSIS
    Parses EQ text data from the clipboard.
 .DESCRIPTION
-   This function processes text data containing EQ settings, extracts relevant information, and returns an array of objects with properties: Frequency, Q, and Gain.
+   This function processes text data containing EQ settings, extracts relevant information, and returns an array of objects with properties: Frequency, Q, Gain, Type and bandNumber.
 .EXAMPLE
    $bands = Read-EQText -Text $clipboardText -QDivider 2.0
    This example parses the EQ data from the clipboard text with a Q Divider of 2.0.
@@ -18,10 +18,11 @@
    [string] $Text - The EQ text data to parse.
    [double] $QDivider - The Divider value for Q.
 .OUTPUTS
-   [array] - An array of objects with Freq, Q, and Gain properties.
+   [array] - An array of objects with Freq, Q, Gain, Type and bandNumber properties.
 .NOTES
    Ensure the input text is in the expected format for proper parsing.
 #>
+
 function Read-EQText {
     param(
         [Parameter(Mandatory = $true)][string]$Text,
@@ -35,30 +36,85 @@ function Read-EQText {
     if (-not $Text) { return @() }
 
     $lines = $Text -split "`r?`n"
-    $bands = $lines[1..$lines.count] | ConvertFrom-Csv -Delimiter "`t"
+    if ($lines.Count -lt 2) { return @() }
+
+    $bands = $lines[1..($lines.Count - 1)] | ConvertFrom-Csv -Delimiter "`t" -ErrorAction SilentlyContinue
+    if (-not $bands) { return @() }
+
+    $validTypes = 'PK','HS','LS','HP','LP'
+    $foundTypes = $bands | ForEach-Object { $_.Type } | Where-Object { $_ -in $validTypes } | Select-Object -Unique
+    $alignment = $null
+    if ($foundTypes -contains 'HP' -or $foundTypes -contains 'LP') {
+        $alignment = Show-CrossoverTypeDialog
+        if (-not $alignment) {
+            Write-Verbose -Message 'Crossover selection cancelled. Using Butterworth fallback.'
+            $alignment = 'Butterworth'
+        }
+    }
 
     $results = @()
     $bandNumber = 1
-    $bands | where-Object { $_.Type -eq 'PK' } | ForEach-Object {
-        if ($QDivider -ne 1) {
-            # Adjust Q value based on QDivider and round to specified decimals
-            $adjustedQ = [math]::round($([double]($_.Q -replace ",", ".") / $QDivider), $QDecimals)
+    foreach ($band in $bands) {
+        if (-not ($band.Type -in $validTypes)) { continue }
+
+        $type = $band.Type
+        $gain = 0.0
+        $freq = 0.0
+        $qValue = $null
+
+        try { $gain = [double]($band.'Gain(dB)' -replace ',', '.') } catch { }
+        try { $freq = [double]($band.'Frequency(Hz)' -replace ',', '.') } catch { }
+
+        $rawQ = $null
+        if ($band.PSObject.Properties.Match('Q')) {
+            $rawQ = $band.Q
         }
-        else {
-            $adjustedQ = [math]::round([double]($_.Q -replace ",", "."), $QDecimals)
+
+        switch ($type) {
+            'PK' {
+                if ($rawQ -ne $null -and $rawQ -ne '') {
+                    $qValue = [double]($rawQ -replace ',', '.')
+                }
+                if ($QDivider -ne 1 -and $qValue -ne $null) {
+                    $qValue = $qValue / $QDivider
+                }
+            }
+            'HS' {
+                $qValue = Get-ComputedQForHSLS -Gain $gain
+            }
+            'LS' {
+                $qValue = Get-ComputedQForHSLS -Gain $gain
+            }
+            'HP' {
+                if ($alignment) {
+                    $qValue = Get-CrossoverQ -Alignment $alignment
+                }
+                else {
+                    $qValue = 0.7071
+                }
+            }
+            'LP' {
+                if ($alignment) {
+                    $qValue = Get-CrossoverQ -Alignment $alignment
+                }
+                else {
+                    $qValue = 0.7071
+                }
+            }
         }
 
-        # Round Frequency to specified decimals
-        $adjustedFreq = [math]::round([double]($_.'Frequency(Hz)' -replace ",", "."), $FreqDecimals)
+        if ($qValue -eq $null -or [double]::IsNaN($qValue) -or [double]::IsInfinity($qValue)) {
+            $qValue = 0.7071
+        }
 
-        # Round Gain to specified decimals
-        $adjustedGain = [math]::round([double]($_.'Gain(dB)' -replace ",", "."), $GainDecimals)
+        $adjustedQ = [math]::round($qValue, $QDecimals)
+        $adjustedFreq = [math]::round($freq, $FreqDecimals)
+        $adjustedGain = [math]::round($gain, $GainDecimals)
 
-        # Replace decimal separator if needed
-        if ($DecimalSeparator -eq ",") {
-            $adjustedFreq = $adjustedFreq.tostring() -replace "\.", ","
-            $adjustedGain = $adjustedGain.tostring() -replace "\.", ","
-            $adjustedQ = $adjustedQ.tostring() -replace "\.", ","
+        if ($DecimalSeparator -eq ',') {
+            $adjustedFreq = $adjustedFreq.ToString() -replace '\.', ','
+            $adjustedGain = $adjustedGain.ToString() -replace '\.', ','
+            $adjustedQ = $adjustedQ.ToString() -replace '\.', ','
         }
 
         $results += [PSCustomObject]@{
@@ -66,21 +122,112 @@ function Read-EQText {
             Q          = [string]($adjustedQ)
             Gain       = [string]($adjustedGain)
             bandNumber = [string]($bandNumber)
+            Type       = $type
         }
         $bandNumber++
     }
 
-    if ($results.count -gt 0) {
-        Write-Verbose -Message "Parsed $($results.count) PK bands from clipboard."
+    if ($results.Count -gt 0) {
+        Write-Verbose -Message "Parsed $($results.Count) bands from clipboard: $($foundTypes -join ', ')"
         return [array]$results
     }
-    else {
-        Write-Verbose -Message "No PK bands found in clipboard."
-        return @()
+
+    Write-Verbose -Message 'No supported EQ bands found in clipboard.'
+    return @()
+}
+
+function Show-CrossoverTypeDialog {
+    Add-Type -AssemblyName System.Windows.Forms
+    Add-Type -AssemblyName System.Drawing
+
+    $form = New-Object System.Windows.Forms.Form
+    $form.Text = 'Choose Crossover Alignment'
+    $form.ClientSize = [System.Drawing.Size]::new(360, 150)
+    $form.StartPosition = 'CenterScreen'
+    $form.FormBorderStyle = 'FixedDialog'
+    $form.MaximizeBox = $false
+    $form.MinimizeBox = $false
+    $form.TopMost = $true
+
+    $label = New-Object System.Windows.Forms.Label
+    $label.Text = 'Select the crossover alignment for HP/LP bands:'
+    $label.AutoSize = $true
+    $label.Location = [System.Drawing.Point]::new(12, 15)
+    $form.Controls.Add($label)
+
+    $combo = New-Object System.Windows.Forms.ComboBox
+    $combo.DropDownStyle = 'DropDownList'
+    $combo.Items.AddRange(@('Butterworth','Linkwitz','Bessel'))
+    $combo.SelectedIndex = 0
+    $combo.Location = [System.Drawing.Point]::new(12, 45)
+    $combo.Width = 330
+    $form.Controls.Add($combo)
+
+    $okButton = New-Object System.Windows.Forms.Button
+    $okButton.Text = 'OK'
+    $okButton.DialogResult = [System.Windows.Forms.DialogResult]::OK
+    $okButton.Location = [System.Drawing.Point]::new(180, 90)
+    $form.Controls.Add($okButton)
+
+    $cancelButton = New-Object System.Windows.Forms.Button
+    $cancelButton.Text = 'Cancel'
+    $cancelButton.DialogResult = [System.Windows.Forms.DialogResult]::Cancel
+    $cancelButton.Location = [System.Drawing.Point]::new(270, 90)
+    $form.Controls.Add($cancelButton)
+
+    $form.AcceptButton = $okButton
+    $form.CancelButton = $cancelButton
+
+    $result = $form.ShowDialog()
+    if ($result -eq [System.Windows.Forms.DialogResult]::OK) {
+        return $combo.SelectedItem
+    }
+
+    return $null
+}
+
+function Get-CrossoverQ {
+    param(
+        [Parameter(Mandatory = $true)][string]$Alignment
+    )
+
+    switch ($Alignment) {
+        'Bessel'     { return 0.5774 }
+        'Linkwitz'   { return 0.5000 }
+        'Butterworth'{ return 0.7071 }
+        default      { return 0.7071 }
     }
 }
+
+function Get-ComputedQForHSLS {
+    param(
+        [Parameter(Mandatory = $true)][double]$Gain
+    )
+
+    $S = 0.9
+    $A = [math]::Pow(10.0, ($Gain / 40.0))
+    $term1 = $A + (1.0 / $A)
+    $term2 = (1.0 / $S) - 1.0
+    $denominator = [math]::Sqrt(($term1 * $term2) + 2.0)
+
+    if ($denominator -eq 0 -or [double]::IsNaN($denominator) -or [double]::IsInfinity($denominator)) {
+        return 0.7071
+    }
+
+    $q = 1.0 / $denominator
+    if ([double]::IsNaN($q) -or [double]::IsInfinity($q) -or $q -le 0) {
+        return 0.7071
+    }
+
+    if ($q -lt 0.30) {
+        $q = 0.30
+    }
+
+    return [math]::Round($q, 4)
+}
+
 # debug start
-# Read-EQText -text $(get-clipboard -raw) -QDivider 1 -QDecimals 1 -GainDecimals 1 -DecimalSeparator "." -FreqDecimals 1 | Format-Table -AutoSize
+# Read-EQText -text $(get-clipboard -raw) -QDivider 1 -QDecimals 1 -GainDecimals 1 -DecimalSeparator '.' -FreqDecimals 1 | Format-Table -AutoSize
 # debug end
 
 # Show a confirmation dialog to the user and return their response as a boolean.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The tool uses its own profiles (in JSON format), which store the DSP software ap
 | Ground Zero | GZHA MINI FIVE-DSP_GUI  | ❎ | ⌨️🖱️ | GZHA MINI FIVE-DSP |
 | Ground Zero | GZDSP 6-10SQ | ❎ | ⌨️ | GZDSP 6-10SQ |
 | Goldhorn | Goldhorn DSP software | ❎ | ⌨️🖱️ | P5/P3/P2/P1 and all DSPA models |
+| STEG | STEG DSP software | ❎ | ⌨️ | STEG series DSPs |
 | Rebec | R6 | ❎ | ⌨️🖱️ | R6s DSP/Amplifier |
 | Rebec | RebecA6A8 | ❎ | ⌨️ | DSP 406Q, A6 and A8 |
 | Rebec | Rebec 8-12v3 | ❎ | ⌨️ | 812v3 |
@@ -82,6 +83,17 @@ The tool uses its own profiles (in JSON format), which store the DSP software ap
 Completed tasks and upcoming plans in [TODOs.md](TODOs.md)
 
 ## Recent updates
+
+### 10.08.2026
+Updated REW parsing and Q handling for HS/LS and HP/LP filters.
+- HS/LS shelf filters now compute Q when REW does not provide a valid Q value, using the standard REW shelf formula with S = 0.9. The result is clamped to a minimum of 0.30 to avoid unrealistic low-Q values.
+- HP/LP filters now prompt the user for the crossover alignment type when these bands appear, and then apply fixed Q values:
+  - Butterworth: 0.7071
+  - Linkwitz: 0.5000
+  - Bessel: 0.5774
+- STEG DSP profile added to the tested profile list.
+- This means the tool now supports both shelf Q calculation and explicit crossover alignment selection for LPF/HPF bands.
+Implemented by @wagnerfcruz.
 
 ### 14.04.2026
 ver 0.6.1<br>

--- a/Resources/Config.json
+++ b/Resources/Config.json
@@ -8,5 +8,5 @@
     "FreqDecimals":  0,
     "DecimalSeparator":  ".",
     "TimeoutBeforePasteSecs":  6,
-    "LastSelectedProfile":  "ESX ESXToolkit"
+    "LastSelectedProfile":  "STEG_window125"
 }


### PR DESCRIPTION
Updated REW parsing and Q handling for HS/LS and HP/LP filters.
- HS/LS shelf filters now compute Q when REW does not provide a valid Q value, using the standard REW shelf formula with S = 0.9. The result is clamped to a minimum of 0.30 to avoid unrealistic low-Q values.
- HP/LP filters now prompt the user for the crossover alignment type when these bands appear, and then apply fixed Q values:
  - Butterworth: 0.7071
  - Linkwitz: 0.5000
  - Bessel: 0.5774
- STEG DSP profile added to the tested profile list.
- This means the tool now supports both shelf Q calculation and explicit crossover alignment selection for LPF/HPF bands.
Implemented by @wagnerfcruz.